### PR TITLE
deprecating repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# THIS REPOSITORY IS DEPRECATED, SEE BELOW FOR THE UP-TO-DATE VERSION
+
+New version: https://github.com/binder-examples/conda_environment
+
+---
+
 # Example Binder with environment.yml
 
 [![Binder](http://mybinder.org/badge.svg)](http://mybinder.org/repo/binder-project/example-conda-environment)


### PR DESCRIPTION
@yuvipanda @freeman-lab does this look reasonable for a deprecation message? The idea is to point folks to the new `binder-examples` organization since that's where up-to-date examples will live.

I'll do the same for all the other repos as we make sure they work with the new binder deployment